### PR TITLE
Fix the names so it matches with what is in the db

### DIFF
--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelActivity.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelActivity.java
@@ -26,9 +26,9 @@ public class FuelActivity {
         NONE("none"),
         FUEL_FILL(Event.TYPE_FUEL_FILL),
         FUEL_DRAIN(Event.TYPE_FUEL_DRAIN),
-        PROBABLE_FILL(Event.TYPE_PROBABLE_FILL),
-        PROBABLE_DRAIN(Event.TYPE_PROBABLE_DRAIN),
-        EXPECTED_FILL(Event.TYPE_EXPECTED_FILL);
+        PROBABLE_FUEL_FILL(Event.TYPE_PROBABLE_FILL),
+        PROBABLE_FUEL_DRAIN(Event.TYPE_PROBABLE_DRAIN),
+        EXPECTED_FUEL_FILL(Event.TYPE_EXPECTED_FILL);
 
         private String nameString;
 

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataActivityChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataActivityChecker.java
@@ -186,7 +186,7 @@ public class FuelDataActivityChecker {
                             Math.abs(calculatedFuelChangeVolume) -
                                     expectedFuelConsumption.expectedCurrentFuelConsumed;
                     FuelActivity activity =
-                            new FuelActivity(FuelActivity.FuelActivityType.PROBABLE_DRAIN,
+                            new FuelActivity(FuelActivity.FuelActivityType.PROBABLE_FUEL_DRAIN,
                                              possibleFuelDrain, lastPosition, position);
                     return Optional.of(activity);
                 } else {
@@ -194,7 +194,7 @@ public class FuelDataActivityChecker {
                             expectedFuelConsumption.expectedCurrentFuelConsumed -
                                     Math.abs(calculatedFuelChangeVolume);
                     FuelActivity activity =
-                            new FuelActivity(FuelActivity.FuelActivityType.PROBABLE_FILL,
+                            new FuelActivity(FuelActivity.FuelActivityType.PROBABLE_FUEL_FILL,
                                              possibleFuelFill, lastPosition, position);
                     return Optional.of(activity);
                 }
@@ -202,7 +202,7 @@ public class FuelDataActivityChecker {
                 double expectedFuelFill =
                         calculatedFuelChangeVolume + expectedFuelConsumption.expectedCurrentFuelConsumed;
                 FuelActivity activity =
-                        new FuelActivity(FuelActivity.FuelActivityType.EXPECTED_FILL,
+                        new FuelActivity(FuelActivity.FuelActivityType.EXPECTED_FUEL_FILL,
                                          expectedFuelFill, lastPosition, position);
                 return Optional.of(activity);
             }


### PR DESCRIPTION
Found this by chance. I wasn't using the right name to pass on to the FCM notifier, which was resulting in NPEs, and the data loss flag maps not getting cleared - which in turn resulted in drains due to loss be detected on every payload that came in!