### PR TITLE
Handle hourly devices and interpolation 

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -35,6 +35,7 @@
     <entry key='processing.peripheralSensorData.storedEventLookAroundSeconds'>300</entry>
     <entry key='processing.peripheralSensorData.currentEventLookBackSeconds'>2400</entry>
     <entry key='processing.peripheralSensorData.dataLossThresholdSeconds'>300</entry>
+    <entry key='processing.peripheralSensorData.lookAroundTimeForPacketLossSeconds'>300</entry>
 
     <entry key='processing.peripheralSensorData.minValuesForMovingAverage'>9</entry>
     <entry key='processing.peripheralSensorData.minValuesForOutlierDetection'>21</entry>
@@ -47,6 +48,7 @@
     <entry key='processing.minimumAverageMileage'>1.5</entry>
     <entry key='processing.maximumAverageMileage'>4.0</entry>
     <entry key='processing.currentAverageMileage'>2.5</entry>
+    <entry key='processing.transmissionFrequencySeconds'>60</entry>
 
     <!--<entry key='database.driver'>org.h2.Driver</entry>-->
     <!--<entry key='database.url'>jdbc:h2:./target/database</entry>-->

--- a/pom.xml
+++ b/pom.xml
@@ -70,8 +70,8 @@
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP-java7</artifactId>
-            <version>2.4.13</version>
+            <artifactId>HikariCP</artifactId>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -34,6 +34,7 @@ import org.traccar.model.DeviceTotalDistance;
 import org.traccar.model.Group;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
+import org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors.DeviceConsumptionInfo;
 
 public class DeviceManager extends BaseObjectManager<Device> implements IdentityManager, ManagableObjects {
 
@@ -50,6 +51,8 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
     private final Map<Long, Position> positions = new ConcurrentHashMap<>();
 
     private final Map<Long, DeviceState> deviceStates = new ConcurrentHashMap<>();
+
+    private final Map<Long, DeviceConsumptionInfo> deviceConsumptionMap = new ConcurrentHashMap<>();
 
     public DeviceManager(DataManager dataManager) {
         super(dataManager, Device.class);
@@ -197,6 +200,22 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
             cachedDevice.setPhone(device.getPhone());
             putPhone(cachedDevice);
         }
+
+        // We're not checking if the map contains info on the device or not, so we have the latest updated attributes.
+        DeviceConsumptionInfo deviceConsumptionInfo = new DeviceConsumptionInfo(device);
+        deviceConsumptionMap.put(device.getId(), deviceConsumptionInfo);
+
+    }
+
+    public DeviceConsumptionInfo getDeviceConsumptionInfo(long deviceId) {
+        refreshItems();
+
+        if (deviceConsumptionMap.containsKey(deviceId)) {
+            return deviceConsumptionMap.get(deviceId);
+        }
+
+        // Return with defaults;
+        return new DeviceConsumptionInfo();
     }
 
     @Override

--- a/src/org/traccar/database/DeviceManager.java
+++ b/src/org/traccar/database/DeviceManager.java
@@ -34,7 +34,7 @@ import org.traccar.model.DeviceTotalDistance;
 import org.traccar.model.Group;
 import org.traccar.model.Position;
 import org.traccar.model.Server;
-import org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors.DeviceConsumptionInfo;
+import org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors.DeviceAttributes;
 
 public class DeviceManager extends BaseObjectManager<Device> implements IdentityManager, ManagableObjects {
 
@@ -52,7 +52,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
 
     private final Map<Long, DeviceState> deviceStates = new ConcurrentHashMap<>();
 
-    private final Map<Long, DeviceConsumptionInfo> deviceConsumptionMap = new ConcurrentHashMap<>();
+    private final Map<Long, DeviceAttributes> deviceConsumptionMap = new ConcurrentHashMap<>();
 
     public DeviceManager(DataManager dataManager) {
         super(dataManager, Device.class);
@@ -202,12 +202,12 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
         }
 
         // We're not checking if the map contains info on the device or not, so we have the latest updated attributes.
-        DeviceConsumptionInfo deviceConsumptionInfo = new DeviceConsumptionInfo(device);
-        deviceConsumptionMap.put(device.getId(), deviceConsumptionInfo);
+        DeviceAttributes deviceAttributes = new DeviceAttributes(device);
+        deviceConsumptionMap.put(device.getId(), deviceAttributes);
 
     }
 
-    public DeviceConsumptionInfo getDeviceConsumptionInfo(long deviceId) {
+    public DeviceAttributes getDeviceAttributes(long deviceId) {
         refreshItems();
 
         if (deviceConsumptionMap.containsKey(deviceId)) {
@@ -215,7 +215,7 @@ public class DeviceManager extends BaseObjectManager<Device> implements Identity
         }
 
         // Return with defaults;
-        return new DeviceConsumptionInfo();
+        return new DeviceAttributes();
     }
 
     @Override

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceAttributes.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceAttributes.java
@@ -4,7 +4,7 @@ import org.apache.commons.lang.StringUtils;
 import org.traccar.Context;
 import org.traccar.model.Device;
 
-public class DeviceConsumptionInfo {
+public class DeviceAttributes {
     private static final String CONSUMPTION_TYPE_ATTR = "consumption";
     private static final String DEFAULT_CONSUMPTION_TYPE = "empty";
 
@@ -12,11 +12,13 @@ public class DeviceConsumptionInfo {
     private static final String MAX_AVG_CONSUMPTION_RATE_ATTR = "maxAvgConsumptionRate";
     private static final String ASSUMED_AVG_CONSUMPTION_RATE_ATTR = "assumedAvgConsumptionRate";
     private static final String FUEL_ACTIVITY_THRESHOLD_ATTR = "fuelActivityThreshold";
+    private static final String DEFAULT_TRANSMISSION_FREQ_ATTR = "transmissionFreq";
 
     private static final double DEFAULT_FUEL_ACTIVITY_THRESHOLD;
     private static final double MIN_AVG_CONSUMPTION_RATE;
     private static final double MAX_AVG_CONSUMPTION_RATE;
     private static final double ASSUMED_AVG_CONSUMPTION_RATE;
+    private static final int DEFAULT_TRANSMISSION_FREQ_SECONDS;
 
 
     static {
@@ -26,6 +28,7 @@ public class DeviceConsumptionInfo {
         MIN_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.minimumAverageMileage");
         MAX_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.maximumAverageMileage");
         ASSUMED_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.currentAverageMileage");
+        DEFAULT_TRANSMISSION_FREQ_SECONDS = Context.getConfig().getInteger("processing.transmissionFrequencySeconds");
     }
 
     private String deviceConsumptionType;
@@ -33,16 +36,18 @@ public class DeviceConsumptionInfo {
     private double maxDeviceConsumptionRate;
     private double assumedDeviceConsumptionRate;
     private double fuelActivityThreshold;
+    private int transmissionFrequencySeconds;
 
-    public DeviceConsumptionInfo() {
+    public DeviceAttributes() {
         deviceConsumptionType = DEFAULT_CONSUMPTION_TYPE;
         minDeviceConsumptionRate = MIN_AVG_CONSUMPTION_RATE;
         maxDeviceConsumptionRate = MAX_AVG_CONSUMPTION_RATE;
         assumedDeviceConsumptionRate = ASSUMED_AVG_CONSUMPTION_RATE;
         fuelActivityThreshold = DEFAULT_FUEL_ACTIVITY_THRESHOLD;
+        transmissionFrequencySeconds = DEFAULT_TRANSMISSION_FREQ_SECONDS;
     }
 
-    public DeviceConsumptionInfo(Device device) {
+    public DeviceAttributes(Device device) {
         this();
 
         if (StringUtils.isNotBlank(device.getString(CONSUMPTION_TYPE_ATTR))) {
@@ -65,6 +70,10 @@ public class DeviceConsumptionInfo {
             fuelActivityThreshold = device.getDouble(FUEL_ACTIVITY_THRESHOLD_ATTR);
         }
 
+        if (device.getAttributes().containsKey(DEFAULT_TRANSMISSION_FREQ_ATTR)) {
+            transmissionFrequencySeconds = device.getInteger(DEFAULT_TRANSMISSION_FREQ_ATTR);
+        }
+
     }
 
     public String getDeviceConsumptionType() {
@@ -85,5 +94,9 @@ public class DeviceConsumptionInfo {
 
     public double getFuelActivityThreshold() {
         return fuelActivityThreshold;
+    }
+
+    public int getTransmissionFrequencySeconds() {
+        return transmissionFrequencySeconds;
     }
 }

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceConsumptionInfo.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceConsumptionInfo.java
@@ -1,0 +1,89 @@
+package org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors;
+
+import org.apache.commons.lang.StringUtils;
+import org.traccar.Context;
+import org.traccar.model.Device;
+
+public class DeviceConsumptionInfo {
+    private static final String CONSUMPTION_TYPE_ATTR = "consumption";
+    private static final String DEFAULT_CONSUMPTION_TYPE = "empty";
+
+    private static final String MIN_AVG_CONSUMPTION_RATE_ATTR = "minAvgConsumptionRate";
+    private static final String MAX_AVG_CONSUMPTION_RATE_ATTR = "maxAvgConsumptionRate";
+    private static final String ASSUMED_AVG_CONSUMPTION_RATE_ATTR = "assumedAvgConsumptionRate";
+    private static final String FUEL_ACTIVITY_THRESHOLD_ATTR = "fuelActivityThreshold";
+
+    private static final double DEFAULT_FUEL_ACTIVITY_THRESHOLD;
+    private static final double MIN_AVG_CONSUMPTION_RATE;
+    private static final double MAX_AVG_CONSUMPTION_RATE;
+    private static final double ASSUMED_AVG_CONSUMPTION_RATE;
+
+
+    static {
+        DEFAULT_FUEL_ACTIVITY_THRESHOLD =
+                Context.getConfig().getDouble("processing.peripheralSensorData.fuelLevelChangeThresholdLiters");
+
+        MIN_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.minimumAverageMileage");
+        MAX_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.maximumAverageMileage");
+        ASSUMED_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.currentAverageMileage");
+    }
+
+    private String deviceConsumptionType;
+    private double minDeviceConsumptionRate;
+    private double maxDeviceConsumptionRate;
+    private double assumedDeviceConsumptionRate;
+    private double fuelActivityThreshold;
+
+    public DeviceConsumptionInfo() {
+        deviceConsumptionType = DEFAULT_CONSUMPTION_TYPE;
+        minDeviceConsumptionRate = MIN_AVG_CONSUMPTION_RATE;
+        maxDeviceConsumptionRate = MAX_AVG_CONSUMPTION_RATE;
+        assumedDeviceConsumptionRate = ASSUMED_AVG_CONSUMPTION_RATE;
+        fuelActivityThreshold = DEFAULT_FUEL_ACTIVITY_THRESHOLD;
+    }
+
+    public DeviceConsumptionInfo(Device device) {
+        this();
+
+        if (StringUtils.isNotBlank(device.getString(CONSUMPTION_TYPE_ATTR))) {
+            deviceConsumptionType = device.getString(CONSUMPTION_TYPE_ATTR);
+        }
+
+        if (device.getAttributes().containsKey(MIN_AVG_CONSUMPTION_RATE_ATTR)) {
+            minDeviceConsumptionRate = device.getDouble(MIN_AVG_CONSUMPTION_RATE_ATTR);
+        }
+
+        if (device.getAttributes().containsKey(MAX_AVG_CONSUMPTION_RATE_ATTR)) {
+            maxDeviceConsumptionRate = device.getDouble(MAX_AVG_CONSUMPTION_RATE_ATTR);
+        }
+
+        if (device.getAttributes().containsKey(ASSUMED_AVG_CONSUMPTION_RATE_ATTR)) {
+            assumedDeviceConsumptionRate = device.getDouble(ASSUMED_AVG_CONSUMPTION_RATE_ATTR);
+        }
+
+        if (device.getAttributes().containsKey(FUEL_ACTIVITY_THRESHOLD_ATTR)) {
+            fuelActivityThreshold = device.getDouble(FUEL_ACTIVITY_THRESHOLD_ATTR);
+        }
+
+    }
+
+    public String getDeviceConsumptionType() {
+        return deviceConsumptionType;
+    }
+
+    public double getMinDeviceConsumptionRate() {
+        return minDeviceConsumptionRate;
+    }
+
+    public double getMaxDeviceConsumptionRate() {
+        return maxDeviceConsumptionRate;
+    }
+
+    public double getAssumedDeviceConsumptionRate() {
+        return assumedDeviceConsumptionRate;
+    }
+
+    public double getFuelActivityThreshold() {
+        return fuelActivityThreshold;
+    }
+}

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/ExpectedFuelConsumption.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/ExpectedFuelConsumption.java
@@ -1,34 +1,39 @@
 package org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors;
 
 public class ExpectedFuelConsumption {
-    double maximumDistanceTravelled;
     double expectedMinFuelConsumed;
     double expectedMaxFuelConsumed;
     double expectedCurrentFuelConsumed;
     double allowedDeviation;
 
+    private long maxRunningTimeMillis;
+    private double maximumDistanceTravelled;
+
     public ExpectedFuelConsumption(
             double expectedMinFuelConsumed,
             double expectedMaxFuelConsumed,
             double expectedCurrentFuelConsumed,
-            double allowedDeviation,
-            double maximumDistanceTravelled) {
+            double allowedDeviation) {
 
         this.expectedCurrentFuelConsumed = expectedCurrentFuelConsumed;
         this.expectedMaxFuelConsumed = expectedMaxFuelConsumed;
         this.expectedMinFuelConsumed = expectedMinFuelConsumed;
         this.allowedDeviation = allowedDeviation;
-        this.maximumDistanceTravelled = maximumDistanceTravelled;
     }
 
-    @Override
-    public String toString() {
-        String maxDist = String.format("Maximum Distance Travelled: %f", maximumDistanceTravelled);
-        String minFuel = String.format("Expected Min fuel consumed: %f", expectedMinFuelConsumed);
-        String maxFuel = String.format("Expected max fuel consumed: %f", expectedMaxFuelConsumed);
-        String currentFuel = String.format("Expected current fuel consumed %f", expectedCurrentFuelConsumed);
-        String deviation = String.format("Allowed deviation: %f", allowedDeviation);
+    public long getMaxRunningTimeMillis() {
+        return maxRunningTimeMillis;
+    }
 
-        return String.format("%s%n%s%n%s%n%s%n%s%n", maxDist, minFuel, maxFuel, currentFuel, deviation);
+    public void setMaxRunningTimeMillis(long maxRunningTimeMillis) {
+        this.maxRunningTimeMillis = maxRunningTimeMillis;
+    }
+
+    public double getMaximumDistanceTravelled() {
+        return maximumDistanceTravelled;
+    }
+
+    public void setMaximumDistanceTravelled(double maximumDistanceTravelled) {
+        this.maximumDistanceTravelled = maximumDistanceTravelled;
     }
 }

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataLossChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataLossChecker.java
@@ -23,7 +23,7 @@ public class FuelDataLossChecker {
 
 
         long deviceId = startPosition.getDeviceId();
-        DeviceConsumptionInfo consumptionInfo = Context.getDeviceManager().getDeviceConsumptionInfo(deviceId);
+        DeviceAttributes consumptionInfo = Context.getDeviceManager().getDeviceAttributes(deviceId);
         boolean requiredFieldsPresent = checkRequiredFieldsPresent(startPosition, endPosition, consumptionInfo);
 
         if (!requiredFieldsPresent) {
@@ -57,7 +57,7 @@ public class FuelDataLossChecker {
 
     public static boolean checkRequiredFieldsPresent(Position startPosition,
                                                      Position endPosition,
-                                                     DeviceConsumptionInfo consumptionInfo) {
+                                                     DeviceAttributes consumptionInfo) {
 
         String consumptionType = consumptionInfo.getDeviceConsumptionType().toLowerCase();
         switch (consumptionType) {
@@ -84,7 +84,7 @@ public class FuelDataLossChecker {
     public static ExpectedFuelConsumption getExpectedFuelConsumptionValues(Position startPosition,
                                                                            Position endPosition,
                                                                            Optional<Long> maxCapacity,
-                                                                           DeviceConsumptionInfo consumptionInfo) {
+                                                                           DeviceAttributes consumptionInfo) {
 
         double allowedDeviation = maxCapacity.orElse(DEFAULT_MAX_CAPACITY) * 0.01;
 
@@ -115,7 +115,7 @@ public class FuelDataLossChecker {
     private static ExpectedFuelConsumption getExpectedDistanceFuelConsumptionValues(Position startPosition,
                                                                                     Position endPosition,
                                                                                     double allowedDeviation,
-                                                                                    DeviceConsumptionInfo consumptionInfo) {
+                                                                                    DeviceAttributes consumptionInfo) {
 
         double startTotalGPSDistanceInMeters = (double) startPosition.getAttributes().get(Position.KEY_TOTAL_DISTANCE);
         double endTotalGPSDistanceInMeters = (double) endPosition.getAttributes().get(Position.KEY_TOTAL_DISTANCE);
@@ -157,7 +157,7 @@ public class FuelDataLossChecker {
     private static ExpectedFuelConsumption getExpectedHourlyFuelConsumptionValues(Position startPosition,
                                                                                   Position endPosition,
                                                                                   double allowedDeviation,
-                                                                                  DeviceConsumptionInfo consumptionInfo) {
+                                                                                  DeviceAttributes consumptionInfo) {
 
         long maxRunningTime = endPosition.getLong(Position.KEY_TOTAL_IGN_ON_MILLIS) - startPosition.getLong(Position.KEY_TOTAL_IGN_ON_MILLIS);
 

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandlerHelper.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandlerHelper.java
@@ -27,6 +27,7 @@ public class FuelSensorDataHandlerHelper {
                                                              Position position,
                                                              int minListSize,
                                                              int currentEventLookBackSeconds) {
+
         return getRelevantPositionsSubList(positionsForSensor,
                                            position,
                                            minListSize,
@@ -205,5 +206,22 @@ public class FuelSensorDataHandlerHelper {
         } catch (SQLException e) {
             Log.debug("Exception while updating outlier position with id: " + outlierPosition.getId());
         }
+    }
+
+    public static double getMedianValue(final List<Position> readingsForDevice,
+                                         final int start,
+                                         final int end) {
+
+        final List<Double> readings = readingsForDevice.subList(start, end)
+                                                       .stream()
+                                                       .map(p -> (double) p.getAttributes()
+                                                                           .get(Position.KEY_CALIBRATED_FUEL_LEVEL))
+                                                       .collect(Collectors.toList());
+
+        // Sort them in the ascending order
+        readings.sort(Comparator.naturalOrder());
+
+        // pick the middle position
+        return readings.get((readings.size() - 1) / 2);
     }
 }


### PR DESCRIPTION
We want to calculate expected fuel consumption based on how the vehicle / machinery consumes (or doesn't consume) fuel. We also wnat to be able to specify a different threshold for fuel activity based on the type of vehicle / machinery. Changes here address both of these requirements. The current values that live in the config file, will carry forward as defaults in cases where the expected values are not set in the db. These are only sensible fallbacks.

Change also include interpolation if packets are lost