### PR TITLE
More updates for multiple sensor handling

### DIFF
--- a/debug.xml
+++ b/debug.xml
@@ -29,7 +29,7 @@
 
     <!-- Peripheral sensor processing entries-->
     <entry key='processing.peripheralSensorData.enable'>true</entry>
-    <entry key='processing.peripheralSensorData.messageFrequency'>30</entry>
+    <entry key='processing.peripheralSensorData.messageFrequency'>60</entry>
     <entry key='processing.peripheralSensorData.hoursOfDataToLoad'>24</entry>
     <entry key='processing.peripheralSensorData.minHoursOfDataInMemory'>24</entry>
     <entry key='processing.peripheralSensorData.storedEventLookAroundSeconds'>300</entry>

--- a/src/org/traccar/api/resource/DeviceResource.java
+++ b/src/org/traccar/api/resource/DeviceResource.java
@@ -103,6 +103,6 @@ public class DeviceResource extends BaseObjectResource<Device> {
     @GET
     public Response refreshDevices() throws SQLException {
         Context.getDeviceManager().updateDeviceCache(true);
-        return Response.noContent().build();
+        return Response.ok().build();
     }
 }

--- a/src/org/traccar/api/resource/PeripheralSensorResource.java
+++ b/src/org/traccar/api/resource/PeripheralSensorResource.java
@@ -24,7 +24,6 @@ public class PeripheralSensorResource extends BaseObjectResource<PeripheralSenso
         super(PeripheralSensor.class);
     }
 
-    @PermitAll
     @GET
     public Collection<PeripheralSensor> get(@QueryParam("deviceId") Long deviceId) {
         Optional<List<PeripheralSensor>> sensors = Context.getPeripheralSensorManager().getSensorByDeviceId(deviceId);

--- a/src/org/traccar/api/resource/PeripheralSensorResource.java
+++ b/src/org/traccar/api/resource/PeripheralSensorResource.java
@@ -1,0 +1,37 @@
+package org.traccar.api.resource;
+
+import org.traccar.Context;
+import org.traccar.api.BaseObjectResource;
+import org.traccar.model.PeripheralSensor;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+@Path("peripheralsensors")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class PeripheralSensorResource extends BaseObjectResource<PeripheralSensor> {
+
+    public PeripheralSensorResource() {
+        super(PeripheralSensor.class);
+    }
+
+    @PermitAll
+    @GET
+    public Collection<PeripheralSensor> get(@QueryParam("deviceId") Long deviceId) {
+        Optional<List<PeripheralSensor>> sensors = Context.getPeripheralSensorManager().getSensorByDeviceId(deviceId);
+
+        if (sensors.isPresent()) {
+            return sensors.get();
+        }
+        return null;
+    }
+}

--- a/src/org/traccar/database/FCMPushNotificationManager.java
+++ b/src/org/traccar/database/FCMPushNotificationManager.java
@@ -131,7 +131,7 @@ public class FCMPushNotificationManager extends ExtendedObjectManager<FCMPushNot
         Optional<List<Long>> sortedSensorIds = Context.getPeripheralSensorManager().getSortedSensorIds(deviceId);
         StringBuilder tankIndexBuilder = new StringBuilder("detected on");
         if (sortedSensorIds.isPresent() && sortedSensorIds.get().size() > 1 && sortedSensorIds.get().contains(peripheralSensorId)) {
-            tankIndexBuilder.append(String.format(" tank %d of", sortedSensorIds.get().indexOf(peripheralSensorId)));
+            tankIndexBuilder.append(String.format(" tank %d of", (sortedSensorIds.get().indexOf(peripheralSensorId) + 1)));
         }
 
         String title = String.format("[%s] %s %s", eventType, tankIndexBuilder, device.getRegistrationNumber());

--- a/src/org/traccar/database/FCMPushNotificationManager.java
+++ b/src/org/traccar/database/FCMPushNotificationManager.java
@@ -128,10 +128,10 @@ public class FCMPushNotificationManager extends ExtendedObjectManager<FCMPushNot
 
         Device device = Context.getDeviceManager().getById(deviceId);
 
-        List<Long> sortedSensorIds = Context.getPeripheralSensorManager().getSortedSensorIds();
+        Optional<List<Long>> sortedSensorIds = Context.getPeripheralSensorManager().getSortedSensorIds(deviceId);
         StringBuilder tankIndexBuilder = new StringBuilder("detected on");
-        if (sortedSensorIds.size() > 1 && sortedSensorIds.contains(peripheralSensorId)) {
-            tankIndexBuilder.append(String.format(" tank %d of", sortedSensorIds.indexOf(peripheralSensorId)));
+        if (sortedSensorIds.isPresent() && sortedSensorIds.get().size() > 1 && sortedSensorIds.get().contains(peripheralSensorId)) {
+            tankIndexBuilder.append(String.format(" tank %d of", sortedSensorIds.get().indexOf(peripheralSensorId)));
         }
 
         String title = String.format("[%s] %s %s", eventType, tankIndexBuilder, device.getRegistrationNumber());

--- a/src/org/traccar/database/FCMPushNotificationManager.java
+++ b/src/org/traccar/database/FCMPushNotificationManager.java
@@ -9,22 +9,15 @@ import org.joda.time.format.DateTimeFormatter;
 import org.traccar.Context;
 import org.traccar.fcm.PushNotifications;
 import org.traccar.helper.Log;
-import org.traccar.model.Device;
-import org.traccar.model.Event;
-import org.traccar.model.FCMPushNotification;
-import org.traccar.model.Position;
+import org.traccar.model.*;
 import org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors.FuelActivity;
 import org.traccar.processing.peripheralsensorprocessors.fuelsensorprocessors.FuelActivity.FuelActivityType;
 
 import java.sql.SQLException;
 
 import java.text.DecimalFormat;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class FCMPushNotificationManager extends ExtendedObjectManager<FCMPushNotification> {
@@ -119,7 +112,7 @@ public class FCMPushNotificationManager extends ExtendedObjectManager<FCMPushNot
         PushNotifications.getInstance().sendEventNotification(tokens, title, body, ttl);
     }
 
-    public void updateFuelActivity(FuelActivity fuelActivity) {
+    public void updateFuelActivity(FuelActivity fuelActivity, long peripheralSensorId) {
 
         FuelActivityType eventType = fuelActivity.getActivityType();
         if (eventType == FuelActivityType.NONE) {
@@ -134,7 +127,14 @@ public class FCMPushNotificationManager extends ExtendedObjectManager<FCMPushNot
         }
 
         Device device = Context.getDeviceManager().getById(deviceId);
-        String title = String.format("[%s] detected on %s", eventType, device.getRegistrationNumber());
+
+        List<Long> sortedSensorIds = Context.getPeripheralSensorManager().getSortedSensorIds();
+        StringBuilder tankIndexBuilder = new StringBuilder("detected on");
+        if (sortedSensorIds.size() > 1 && sortedSensorIds.contains(peripheralSensorId)) {
+            tankIndexBuilder.append(String.format(" tank %d of", sortedSensorIds.indexOf(peripheralSensorId)));
+        }
+
+        String title = String.format("[%s] %s %s", eventType, tankIndexBuilder, device.getRegistrationNumber());
 
         DecimalFormat formatFuelLevel = new DecimalFormat(".#");
 

--- a/src/org/traccar/database/PeripheralSensorManager.java
+++ b/src/org/traccar/database/PeripheralSensorManager.java
@@ -19,8 +19,6 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
     private final Map<Long, List<PeripheralSensor>> deviceToPeripheralSensorMap =
             new ConcurrentHashMap();
 
-    private final List<Long> sortedSensorIds = Lists.newArrayList();
-
     private final Map<String, FuelSensorCalibration> deviceSensorToCalibrationDataMap =
             new ConcurrentHashMap<>();
 
@@ -43,7 +41,6 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
                         linkedPeripheralSensors = new ArrayList();
                     }
                     linkedPeripheralSensors.add(p);
-                    sortedSensorIds.add(p.getPeripheralSensorId());
                     deviceToPeripheralSensorMap.put(p.getDeviceId(), linkedPeripheralSensors);
 
                     ObjectMapper calibrationDataMapper = new ObjectMapper();
@@ -54,7 +51,6 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
                                                                                  p.getPeripheralSensorId()),
                                                          fuelSensorCalibration);
                 }
-                sortedSensorIds.sort(Long::compareTo);
             } catch (SQLException | IOException e) {
                 e.printStackTrace();
             }
@@ -69,8 +65,17 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
         return Optional.empty();
     }
 
-    public List<Long> getSortedSensorIds() {
-        return sortedSensorIds;
+    public Optional<List<Long>> getSortedSensorIds(long deviceId) {
+        Optional<List<PeripheralSensor>> sensorsOnDevice = getLinkedPeripheralSensors(deviceId);
+        if (sensorsOnDevice.isPresent()) {
+            List<Long> sensorIds = Lists.newArrayList();
+            for (PeripheralSensor sensor : sensorsOnDevice.get()) {
+                sensorIds.add(sensor.getPeripheralSensorId());
+            }
+            sensorIds.sort(Long::compareTo);
+            return Optional.of(sensorIds);
+        }
+        return Optional.empty();
     }
 
     public Optional<FuelSensorCalibration> getDeviceSensorCalibrationData(long deviceId, long peripheralSensorId) {

--- a/src/org/traccar/database/PeripheralSensorManager.java
+++ b/src/org/traccar/database/PeripheralSensorManager.java
@@ -75,8 +75,6 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
     }
 
     public Optional<List<PeripheralSensor>> getSensorByDeviceId(long deviceId) {
-        // Note: Handles only one sensor per  gps device for now.
-
         Optional<List<PeripheralSensor>> sensorOnDevice = getLinkedPeripheralSensors(deviceId);
 
         if (!sensorOnDevice.isPresent()) {

--- a/src/org/traccar/database/PeripheralSensorManager.java
+++ b/src/org/traccar/database/PeripheralSensorManager.java
@@ -1,6 +1,7 @@
 package org.traccar.database;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Lists;
 import org.traccar.Context;
 import org.traccar.helper.Log;
 import org.traccar.model.PeripheralSensor;
@@ -17,6 +18,8 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
 
     private final Map<Long, List<PeripheralSensor>> deviceToPeripheralSensorMap =
             new ConcurrentHashMap();
+
+    private final List<Long> sortedSensorIds = Lists.newArrayList();
 
     private final Map<String, FuelSensorCalibration> deviceSensorToCalibrationDataMap =
             new ConcurrentHashMap<>();
@@ -40,6 +43,7 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
                         linkedPeripheralSensors = new ArrayList();
                     }
                     linkedPeripheralSensors.add(p);
+                    sortedSensorIds.add(p.getPeripheralSensorId());
                     deviceToPeripheralSensorMap.put(p.getDeviceId(), linkedPeripheralSensors);
 
                     ObjectMapper calibrationDataMapper = new ObjectMapper();
@@ -50,6 +54,7 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
                                                                                  p.getPeripheralSensorId()),
                                                          fuelSensorCalibration);
                 }
+                sortedSensorIds.sort(Long::compareTo);
             } catch (SQLException | IOException e) {
                 e.printStackTrace();
             }
@@ -62,6 +67,10 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
         }
 
         return Optional.empty();
+    }
+
+    public List<Long> getSortedSensorIds() {
+        return sortedSensorIds;
     }
 
     public Optional<FuelSensorCalibration> getDeviceSensorCalibrationData(long deviceId, long peripheralSensorId) {

--- a/src/org/traccar/database/PeripheralSensorManager.java
+++ b/src/org/traccar/database/PeripheralSensorManager.java
@@ -72,7 +72,7 @@ public class PeripheralSensorManager extends ExtendedObjectManager<PeripheralSen
             for (PeripheralSensor sensor : sensorsOnDevice.get()) {
                 sensorIds.add(sensor.getPeripheralSensorId());
             }
-            sensorIds.sort(Long::compareTo);
+            sensorIds.sort(Comparator.naturalOrder());
             return Optional.of(sensorIds);
         }
         return Optional.empty();

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceConsumptionInfo.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceConsumptionInfo.java
@@ -12,16 +12,21 @@ public class DeviceConsumptionInfo {
     private static final String MAX_AVG_CONSUMPTION_RATE_ATTR = "maxAvgConsumptionRate";
     private static final String ASSUMED_AVG_CONSUMPTION_RATE_ATTR = "assumedAvgConsumptionRate";
     private static final String FUEL_ACTIVITY_THRESHOLD_ATTR = "fuelActivityThreshold";
+    private static final String TRANSMISSION_FREQUENCY_ATTR = "transmissionFreq";
 
     private static final double DEFAULT_FUEL_ACTIVITY_THRESHOLD;
     private static final double MIN_AVG_CONSUMPTION_RATE;
     private static final double MAX_AVG_CONSUMPTION_RATE;
     private static final double ASSUMED_AVG_CONSUMPTION_RATE;
+    private static final int DEFAULT_TRANSMISSION_FREQUENCY;
 
 
     static {
         DEFAULT_FUEL_ACTIVITY_THRESHOLD =
                 Context.getConfig().getDouble("processing.peripheralSensorData.fuelLevelChangeThresholdLiters");
+
+        DEFAULT_TRANSMISSION_FREQUENCY = Context.getConfig()
+                         .getInteger("processing.peripheralSensorData.messageFrequency");
 
         MIN_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.minimumAverageMileage");
         MAX_AVG_CONSUMPTION_RATE = Context.getConfig().getDouble("processing.maximumAverageMileage");
@@ -33,6 +38,7 @@ public class DeviceConsumptionInfo {
     private double maxDeviceConsumptionRate;
     private double assumedDeviceConsumptionRate;
     private double fuelActivityThreshold;
+    private int transmissionFrequency;
 
     public DeviceConsumptionInfo() {
         deviceConsumptionType = DEFAULT_CONSUMPTION_TYPE;
@@ -40,6 +46,7 @@ public class DeviceConsumptionInfo {
         maxDeviceConsumptionRate = MAX_AVG_CONSUMPTION_RATE;
         assumedDeviceConsumptionRate = ASSUMED_AVG_CONSUMPTION_RATE;
         fuelActivityThreshold = DEFAULT_FUEL_ACTIVITY_THRESHOLD;
+        transmissionFrequency = DEFAULT_TRANSMISSION_FREQUENCY;
     }
 
     public DeviceConsumptionInfo(Device device) {
@@ -65,6 +72,9 @@ public class DeviceConsumptionInfo {
             fuelActivityThreshold = device.getDouble(FUEL_ACTIVITY_THRESHOLD_ATTR);
         }
 
+        if (device.getAttributes().containsKey(TRANSMISSION_FREQUENCY_ATTR)) {
+            transmissionFrequency = device.getInteger(TRANSMISSION_FREQUENCY_ATTR);
+        }
     }
 
     public String getDeviceConsumptionType() {
@@ -85,5 +95,9 @@ public class DeviceConsumptionInfo {
 
     public double getFuelActivityThreshold() {
         return fuelActivityThreshold;
+    }
+
+    public int getTransmissionFrequency() {
+        return transmissionFrequency;
     }
 }

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceConsumptionInfo.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/DeviceConsumptionInfo.java
@@ -6,7 +6,7 @@ import org.traccar.model.Device;
 
 public class DeviceConsumptionInfo {
     private static final String CONSUMPTION_TYPE_ATTR = "consumption";
-    private static final String DEFAULT_CONSUMPTION_TYPE = "empty";
+    private static final String DEFAULT_CONSUMPTION_TYPE = "odometer";
 
     private static final String MIN_AVG_CONSUMPTION_RATE_ATTR = "minAvgConsumptionRate";
     private static final String MAX_AVG_CONSUMPTION_RATE_ATTR = "maxAvgConsumptionRate";

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelConsumptionChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelConsumptionChecker.java
@@ -83,7 +83,8 @@ public class FuelConsumptionChecker {
                                                                            Optional<Long> maxCapacity,
                                                                            DeviceConsumptionInfo consumptionInfo) {
 
-        double allowedDeviation = maxCapacity.orElse(DEFAULT_MAX_CAPACITY) * 0.01;
+        double allowedDeviation = (maxCapacity.map(tankMaxCapacity -> Math.min(tankMaxCapacity, DEFAULT_MAX_CAPACITY))
+                                              .orElse(DEFAULT_MAX_CAPACITY)) * 0.01;
 
         switch (consumptionInfo.getDeviceConsumptionType().toLowerCase()) {
 

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelConsumptionChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelConsumptionChecker.java
@@ -105,7 +105,7 @@ public class FuelConsumptionChecker {
 
             case "empty":
             case "noconsumption":
-                return new ExpectedFuelConsumption(0, 0, 0, 0);
+                return new ExpectedFuelConsumption(0, 0, 0, allowedDeviation);
             default:
                 Log.debug("Found strange fuel consumption category vehicle");
                 return null;

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelConsumptionChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelConsumptionChecker.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public class FuelConsumptionChecker {
 
-    private static final long DEFAULT_MAX_CAPACITY = 100L;
+    private static final long DEFAULT_MAX_CAPACITY = 500L;
     private static final long MILLIS_IN_HOUR = 36_00_000L;
 
     public static boolean isFuelConsumptionAsExpected(Position startPosition,
@@ -29,6 +29,9 @@ public class FuelConsumptionChecker {
             // Not enough info to process data loss.
             return false;
         }
+
+        String maxCapacityString = maxCapacity.map(Object::toString).orElse("n/a");
+        Log.debug(String.format("[ConsumptionChecker] MaxCapacity of sensorId %d on deviceId %d is %s ", fuelSensor.getPeripheralSensorId(), deviceId, maxCapacityString));
 
         ExpectedFuelConsumption expectedFuelConsumption =
                 getExpectedFuelConsumptionValues(startPosition, endPosition, maxCapacity, consumptionInfo);

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataActivityChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataActivityChecker.java
@@ -256,6 +256,9 @@ public class FuelDataActivityChecker {
 
         String calibFuelDataField = fuelSensor.getCalibFuelFieldName();
 
+        String maxCapacityString = maxTankMaxVolume.map(Object::toString).orElse("n/a");
+        Log.debug(String.format("[ActivityChecker] MaxCapacity of sensorId %d on deviceId %d is %s ", fuelSensor.getPeripheralSensorId(), position.getDeviceId(), maxCapacityString));
+
         ExpectedFuelConsumption expectedFuelConsumption =
                 FuelConsumptionChecker.getExpectedFuelConsumptionValues(lastPosition, position, maxTankMaxVolume, consumptionInfo);
 

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataActivityChecker.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataActivityChecker.java
@@ -54,7 +54,17 @@ public class FuelDataActivityChecker {
         Optional<String> possibleActivityStartTypeStartType = determinePossibleActivityStartType(diffInMeans, fillThreshold, drainThreshold);
 
         if (possibleActivityStartTypeStartType.isPresent()) {
-            String activityLookupKey = getActivityLookupKey(deviceSensorLookupKey, possibleActivityStartTypeStartType.get());
+            String startType = possibleActivityStartTypeStartType.get();
+
+            String oppositeEventType = startType.equals(FuelActivityType.FUEL_FILL.name())? FuelActivityType.FUEL_DRAIN.name() :
+                                       FuelActivityType.FUEL_FILL.name();
+
+            String activityLookupKey = getActivityLookupKey(deviceSensorLookupKey, startType);
+            String oppositeActivityLookupKey = getActivityLookupKey(deviceSensorLookupKey, oppositeEventType);
+
+            if (!deviceFuelEventMetadata.containsKey(oppositeActivityLookupKey)) {
+
+            }
 
             if (!deviceFuelEventMetadata.containsKey(activityLookupKey)) {
                 Position midPointPosition = readingsForDevice.get(midPoint);
@@ -215,12 +225,12 @@ public class FuelDataActivityChecker {
         String drainLookupKey = getActivityLookupKey(deviceSensorLookupKey, FuelActivityType.FUEL_DRAIN.name());
         String fillLookupKey = getActivityLookupKey(deviceSensorLookupKey, FuelActivityType.FUEL_FILL.name());
 
-        if (diffInMeans > 0 && Math.abs(diffInMeans) < drainThreshold
+        if (Math.abs(diffInMeans) < drainThreshold
                 && deviceFuelEventMetadata.containsKey(drainLookupKey)) {
             return Optional.of(FuelActivityType.FUEL_DRAIN.name());
         }
 
-        if (diffInMeans < 0 && Math.abs(diffInMeans) < fillThreshold
+        if (Math.abs(diffInMeans) < fillThreshold
                 && deviceFuelEventMetadata.containsKey(fillLookupKey)) {
             return Optional.of(FuelActivityType.FUEL_FILL.name());
         }

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataConstants.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelDataConstants.java
@@ -11,4 +11,14 @@ public class FuelDataConstants {
     // This field on the attributes of a fuel sensor will hold the name of the smoothed fuel
     // data field we want to set on a position
     public final static String SMOOTHED_FUEL_ON_POSITION_NAME = "fuelField";
+
+    public final static String OUTLIER_WINDOW_SIZE_FIELD_NAME = "outlier_window";
+
+    public final static String MOVING_AVG_WINDOW_SIZE_FIELD_NAME = "mavg_window";
+
+    public final static String ALERTS_WINDOW_SIZE_FIELD_NAME = "alerts_window";
+
+    public final static String FILL_THRESHOLD_FIELD_NAME = "fill_threshold";
+
+    public final static String DRAIN_THRESHOLD_FIELD_NAME = "drain_threshold";
 }

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandler.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandler.java
@@ -99,7 +99,7 @@ public class FuelSensorDataHandler extends BaseDataHandler {
                     if (position.getDeviceTime().compareTo((lastPacketProcessed.get().getDeviceTime())) <= 0) {
                         Log.debug(String.format("Backdated packets detected for device: %d. Skipping fuel processing for them",
                                 deviceId));
-                        return position;
+                        continue;
                     }
 
                     if (position.getDeviceTime().getTime() - lastPacketProcessed.get().getDeviceTime().getTime() > dataLossThresholdSeconds) {
@@ -115,11 +115,10 @@ public class FuelSensorDataHandler extends BaseDataHandler {
                         positionsForDeviceSensor.add(position);
                     }
                     removeFirstPositionIfNecessary(positionsForDeviceSensor, lookUpKey);
-                    return position;
+                    continue;
                 }
 
                 processSensorData(position, sensorOnDevice);
-
             }
 
         } catch (Exception e) {

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandler.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandler.java
@@ -371,7 +371,7 @@ public class FuelSensorDataHandler extends BaseDataHandler {
         String fuelDataField = fuelSensor.getFuelDataFieldName();
 
         DeviceConsumptionInfo consumptionInfo = Context.getDeviceManager().getDeviceConsumptionInfo(deviceId);
-        int averagesLookbackSeconds = (fuelSensor.getMovingAvgWindowSize() + 2) * consumptionInfo.getTransmissionFrequency();
+        int averagesLookbackSeconds = (fuelSensor.getMovingAvgWindowSize() + 10) * consumptionInfo.getTransmissionFrequency();
 
         List<Position> relevantPositionsListForAverages =
                 FuelSensorDataHandlerHelper.getRelevantPositionsSubList(
@@ -400,7 +400,7 @@ public class FuelSensorDataHandler extends BaseDataHandler {
         }
 
         // Detect and remove outliers
-        int outlierLookbackSeconds = (fuelSensor.getOutlierWindowSize() + 2) * consumptionInfo.getTransmissionFrequency();
+        int outlierLookbackSeconds = (fuelSensor.getOutlierWindowSize() + 10) * consumptionInfo.getTransmissionFrequency();
         List<Position> relevantPositionsListForOutliers =
                 FuelSensorDataHandlerHelper.getRelevantPositionsSubList(positionsForDeviceSensor,
                                                                         position,
@@ -489,7 +489,7 @@ public class FuelSensorDataHandler extends BaseDataHandler {
             possibleDataLossByDevice.remove(deviceId);
             nonOutlierInLastWindowByDevice.remove(deviceId);
 
-            int alertsLookback = (fuelSensor.getEventsWindowSize() + 2) * consumptionInfo.getTransmissionFrequency();
+            int alertsLookback = (fuelSensor.getEventsWindowSize() + 10) * consumptionInfo.getTransmissionFrequency();
             List<Position> relevantPositionsListForAlerts =
                     FuelSensorDataHandlerHelper.getRelevantPositionsSubList(
                             positionsForDeviceSensor,
@@ -575,7 +575,7 @@ public class FuelSensorDataHandler extends BaseDataHandler {
             // Adding the sensor ID to the FCM notification does not make sense, since the end user does not care
             // about these IDs. In the future, if we think it is necessary, we'll add names to sensors so it is
             // clear which "tank" this notification came from.
-            Context.getFcmPushNotificationManager().updateFuelActivity(fuelActivity);
+            Context.getFcmPushNotificationManager().updateFuelActivity(fuelActivity, peripheralSensorId);
         }
     }
 

--- a/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandlerHelper.java
+++ b/src/org/traccar/processing/peripheralsensorprocessors/fuelsensorprocessors/FuelSensorDataHandlerHelper.java
@@ -44,7 +44,7 @@ public class FuelSensorDataHandlerHelper {
                                                               boolean excludeOutliers,
                                                               int currentEventLookBackSeconds) {
 
-        if (positionsForSensor.size() <= minListSize) {
+        if (positionsForSensor.size() < minListSize) {
             return positionsForSensor.stream()
                                      .filter(p -> !excludeOutliers || positionIsMarkedOutlier(p, sensorOutlierFieldName))
                                      .collect(Collectors.toList());
@@ -58,7 +58,7 @@ public class FuelSensorDataHandlerHelper {
         SortedMultiset<Position> positionsSubset =
                 positionsForSensor.subMultiset(fromPosition, BoundType.OPEN, position, BoundType.CLOSED);
 
-        if (positionsSubset.size() <= minListSize) {
+        if (positionsSubset.size() < minListSize) {
             Log.debug("[RELEVANT_SUBLIST] sublist is lesser than "
                               + minListSize + " returning " + positionsSubset.size());
             return positionsSubset.stream()
@@ -73,7 +73,7 @@ public class FuelSensorDataHandlerHelper {
 
         int listMaxIndex = filteredSublistToReturn.size();
 
-        if (filteredSublistToReturn.size() <= minListSize) {
+        if (filteredSublistToReturn.size() < minListSize) {
             return filteredSublistToReturn;
         }
 
@@ -98,7 +98,8 @@ public class FuelSensorDataHandlerHelper {
 
     public static boolean isOutlierPresentInSublist(List<Position> rawFuelOutlierSublist,
                                                     int indexOfPositionEvaluated,
-                                                    Optional<Long> fuelTankMaxCapacity, PeripheralSensor fuelSensor) {
+                                                    Optional<Long> fuelTankMaxCapacity,
+                                                    PeripheralSensor fuelSensor) {
 
         // Make a copy so we don't affect the original incoming list esp in the sort below,
         // since the order of the incoming list needs to be preserved to remove / mark the right
@@ -108,6 +109,7 @@ public class FuelSensorDataHandlerHelper {
         for (Position p : rawFuelOutlierSublist) {
             Position tempPosition = new Position();
             tempPosition.set(calibFueldField, (double) p.getAttributes().get(calibFueldField));
+            tempPosition.setDeviceTime(p.getDeviceTime());
             copyOfRawValues.add(tempPosition);
         }
 
@@ -171,6 +173,7 @@ public class FuelSensorDataHandlerHelper {
         Log.debug("[OUTLIER_STAT] sumOfValues: " + sumOfValues
                   + " mean: " + mean
                   + " sumOfSquaredDifferenceOfMean: " + sumOfSquaredDifferenceOfMean
+                  + " deviceTime of position evaluated: " + (copyOfRawValues.get(indexOfPositionEvaluated).getDeviceTime())
                   + " rawFuelOfPositionEvaluated: " + rawFuelOfPositionEvaluated
                   + " standardDeviation: " + standardDeviation
                   + " lowerBoundOnRawFuelValue: " + lowerBoundOnRawFuelValue

--- a/src/org/traccar/reports/Route.java
+++ b/src/org/traccar/reports/Route.java
@@ -133,8 +133,8 @@ public final class Route {
         ArrayList<Position> result = new ArrayList<>();
         for (long deviceId: ReportUtils.getDeviceList(deviceIds, groupIds)) {
             Context.getPermissionsManager().checkDevice(userId, deviceId);
-            String deviceType = Context.getDeviceManager().getById(deviceId).getString("type");
-            result.addAll(Context.getDataManager().getPositionsForSummary(deviceId, from, to, deviceType));
+
+            result.addAll(Context.getDataManager().getPositionsForSummary(deviceId, from, to));
         }
         return result;
     }


### PR DESCRIPTION
Notes on the changes:
1. I've added a new endpoint to get peripheral sensors on a device, to use that info on the app side for reporting.
2. Rest of the changes (in the 2nd commit) are for being able to set fillThreshold, drainThreshold, window size for averages, outliers and alerts (events) on a PER SENSOR basis (not per device, on purpose). All of the values fallback to the defaults from the config file debug.xml if they're missing. 
Note that I also had to change the eventsLookBackSeconds values to evaluate how much of the list we want to consider based on the relevant window sizes. 